### PR TITLE
Stand up rsrr with check framework, CLI, and initial check set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__/
+*.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,107 @@
+# rsrr - Rapid Security Review Runner
+
+CLI tool for running automated checks for Eclipse Foundation Rapid Security Reviews.
+
+## Architecture
+
+```
+src/rsrr/
+  base.py            # BaseCheck ABC + Context dataclass
+  checks/
+    ef_project.py    # Example: fetch EF project API data
+    <check_name>.py  # One file per check, each exports Check(BaseCheck)
+  cli.py             # Click CLI: `rsrr list` and `rsrr run`
+  runner.py          # Discovers checks, runs them in dependency waves (asyncio)
+tests/
+  test_base.py       # Context helper tests (e.g. github_get)
+  test_cli.py        # CLI integration tests (Click CliRunner, mocked checks)
+  test_runner.py     # Runner unit tests (discover, run, dependencies)
+```
+
+**Check discovery**: `runner.py` auto-discovers every `.py` file in `checks/` (except `base.py` and `__init__.py`) that exports `class Check(BaseCheck)`. The module filename (without `.py`) becomes the `check_id`.
+
+**Dependency resolution**: Checks with `depends_on = ["other_check_id"]` run after their dependencies complete. Independent checks run in parallel via `asyncio.gather`. Results are stored in `ctx.data[check_id]`.
+
+## Adding a Check
+
+Create `src/rsrr/checks/<check_name>.py`:
+
+```python
+from ..base import BaseCheck
+
+class Check(BaseCheck):
+    name = "Human-readable name"
+    comment = "One-line description"
+    depends_on = ["ef_project"]  # optional, list of check_id strings
+
+    async def run(self) -> Any:
+        # Access dependency results via self.ctx.data["ef_project"]
+        # Access project ID via self.ctx.ef_project_id
+        return result  # stored in ctx.data["<check_name>"]
+```
+
+## Key Patterns
+
+- Use `httpx.AsyncClient` for all HTTP calls (project uses httpx)
+- For GitHub API requests, prefer `await self.ctx.github_get(url)` — it sets the
+  `Accept: application/vnd.github.v3+json` header and an `Authorization: Bearer <token>`
+  header when `ctx.gh_token` is set, and raises on non-2xx responses
+- `ctx.ef_project_id_normalized` replaces `.` with `_` (required for the EF project API URL,
+  e.g. `rt.ecf` → `rt_ecf`)
+- EF project API: `https://projects.eclipse.org/api/projects/{ef_project_id_normalized}`
+- EF project result is a list; `result[0]["github"]["org"]` gives the GitHub org name
+
+## Commands
+
+```bash
+uv run rsrr list              # list all available checks
+uv run rsrr run --ef-project-id technology.csi  # run all checks (JSON to stdout)
+uv run rsrr run --ef-project-id technology.csi ef_project gh_default_security_policy  # run specific checks
+uv run rsrr run --ef-project-id technology.csi --ctx-data result.json  # incremental: skip checks already in result.json, merge new results back
+uv run rsrr run -v --ef-project-id technology.csi  # -v enables INFO logging on the rsrr package
+
+just lint        # ruff check + format check
+just lint-fix    # ruff check --fix + format
+
+uv run pytest tests/           # run all tests
+uv run pytest tests/ -v        # run tests with verbose output
+```
+
+## Project Setup
+
+- **Package manager**: `uv` (lockfile: `uv.lock`)
+- **Linter/formatter**: `ruff` (via `uvx`)
+- **Task runner**: `just` (see `justfile`)
+- **Python**: 3.13+
+- **Key deps**: `click`, `httpx`
+- **Test deps** (dev): `pytest`, `pytest-asyncio`
+
+## Testing
+
+Tests cover `cli.py`, `runner.py`, and `base.py` — not individual check implementations.
+
+- **CLI tests** (`tests/test_cli.py`): use `click.testing.CliRunner` with `unittest.mock.patch` on `get_all_checks` to inject fake check classes. No network calls.
+- **Runner tests** (`tests/test_runner.py`): use simple `BaseCheck` subclasses defined inline. `test_discover_checks` writes temp modules to `tmp_path` and runs real discovery.
+- **Base tests** (`tests/test_base.py`): exercise `Context.github_get` with `httpx.AsyncClient` mocked, asserting headers (incl. `Authorization` when `gh_token` is set).
+- Async tests use `@pytest.mark.asyncio` (requires `pytest-asyncio`; asyncio mode configured as `strict` in `pyproject.toml`).
+
+## Sandbox / CI Environment
+
+This project is developed on macOS but Claude Code runs in a Docker (Linux) sandbox.
+The `.venv/` in the project root belongs to the host — **do not touch it from the sandbox**.
+
+In the sandbox, use a separate venv via `UV_PROJECT_ENVIRONMENT`:
+
+```bash
+uv venv /tmp/rsrr-venv --python 3.13
+export UV_PROJECT_ENVIRONMENT=/tmp/rsrr-venv
+uv sync
+uv run pytest tests/ -v   # uses /tmp/rsrr-venv
+uv run rsrr list           # uses /tmp/rsrr-venv
+```
+
+Set `UV_PROJECT_ENVIRONMENT` before any `uv run`/`uv sync` command.
+
+## Directory Notes
+
+- `.venv/` — host-managed by uv, do not modify from sandbox/CI

--- a/README.md
+++ b/README.md
@@ -18,12 +18,56 @@ Check results are printed as JSON to stdout.
 rsrr run [opts]
 
 # Run specific checks
-rsrr run --ef-project-id technology.csi -- ef_committers_count
+rsrr run --ef-project-id technology.csi -- ef_committers
 
 # List available checks
 rsrr list
 
 ```
+
+## Access tokens
+
+Several checks require API tokens. Create them with the minimum scopes needed
+by the checks in this tool:
+
+- **GitHub** (classic personal access token) — needed for Dependabot alerts,
+  security advisories, and private-vulnerability-reporting endpoints. Pass via
+  `--gh-token` or `GH_TOKEN`:
+
+  [Create token](https://github.com/settings/tokens/new?description=rsrr&scopes=repo,security_events)
+  (scopes: `repo`, `security_events`)
+
+  *Alternative: Mint a token from an active `gh` session, and pass it like so: `--gh-token $(gh auth token)`*
+
+- **GitLab** (eclipse.org instance) — needed to search the
+  `security/vulnerability-reports` project. Pass via `--gl-token` or
+  `GL_TOKEN`:
+
+  [Create token](https://gitlab.eclipse.org/-/user_settings/personal_access_tokens?name=rsrr&scopes=read_api)
+  (scope: `read_api`)
+
+
+## Usage Example
+```bash
+
+uv run rsrr --verbose run \
+    --gh-token $(gh auth token) \
+    --gl-token ${GL_TOKEN} \
+    --ef-project-id technology.csi \
+    --gh-repo eclipse-csi/otterdog \
+    --gl-vuln-kw otterdog --gl-vuln-kw self-service \
+    --ctx-data otterdog-rsr.json
+```
+
+### Explanation
+
+- `--gh-token`: use `gh` session, as alternative for creating a token
+- `--gl-token`: redundant use of option for demo purpose, `GL_TOKEN` env var is enough
+- `--ef-project-id`: Review "Common Security Infrastructure" project
+- `--gh-repo`: Focus on Otterdog repo for detailed checks
+- `--gl-vuln-kw`: Search for vulnerability-reports with 'otterdog' or 'self-service' in title or description
+- `--ctx-data`: Save output to otterdog-rsr.json
+
 
 ## Adding a new Check
 
@@ -31,7 +75,7 @@ Create a new file in `src/rsrr/checks/` with a descriptive name, e.g.
 `ultimate_answer.py`, and add a `Check` implementation, e.g.
 
 ```python
-from .base import BaseCheck
+from ..base import BaseCheck
 
 class Check(BaseCheck):
     name = "Ultimate Answer"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,9 @@ rsrr = "rsrr.cli:main"
 [build-system]
 requires = ["uv_build>=0.9.17,<0.10.0"]
 build-backend = "uv_build"
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.2",
+    "pytest-asyncio>=1.3.0",
+]

--- a/src/rsrr/base.py
+++ b/src/rsrr/base.py
@@ -2,10 +2,16 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any
 
+import httpx
+
 
 @dataclass
 class Context:
     ef_project_id: str | None = None
+    gh_repo: str | None = None
+    gh_token: str | None = None
+    gl_token: str | None = None
+    gl_vuln_kw: tuple[str, ...] = ()
     data: dict[str, Any] = field(default_factory=dict)
 
     @property
@@ -13,6 +19,16 @@ class Context:
         if self.ef_project_id is None:
             return None
         return self.ef_project_id.replace(".", "_")
+
+    async def github_get(self, url: str) -> httpx.Response:
+        """Send an authenticated GET request to the GitHub API."""
+        headers = {"Accept": "application/vnd.github.v3+json"}
+        if self.gh_token:
+            headers["Authorization"] = f"Bearer {self.gh_token}"
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url, headers=headers)
+        response.raise_for_status()
+        return response
 
 
 class BaseCheck(ABC):

--- a/src/rsrr/checks/__init__.py
+++ b/src/rsrr/checks/__init__.py
@@ -1,3 +1,3 @@
-from .base import BaseCheck, Context
+from ..base import BaseCheck, Context
 
 __all__ = ["BaseCheck", "Context"]

--- a/src/rsrr/checks/ef_committers.py
+++ b/src/rsrr/checks/ef_committers.py
@@ -1,0 +1,41 @@
+import logging
+
+import httpx
+
+from ..base import BaseCheck
+
+logger = logging.getLogger(__name__)
+
+
+class Check(BaseCheck):
+    name = "EF Committer Profiles"
+    comment = "Fetches detailed profile info for each project committer from the EF API"
+    depends_on = ["ef_project"]
+
+    async def run(self) -> list[dict]:
+        project = self.ctx.data["ef_project"]
+        committers = project.get("committers", [])
+
+        results = []
+        async with httpx.AsyncClient() as client:
+            for committer in committers:
+                url = committer.get("url", "")
+                username = committer.get("username", "")
+                if not url:
+                    continue
+
+                try:
+                    response = await client.get(url)
+                    response.raise_for_status()
+                    details = response.json()
+                    results.append(
+                        {
+                            "first_name": details["first_name"],
+                            "last_name": details["last_name"],
+                            "github_handle": details["github_handle"],
+                        }
+                    )
+                except httpx.HTTPStatusError as e:
+                    logger.error(f"{username}: {e}")
+
+        return results

--- a/src/rsrr/checks/ef_cves.py
+++ b/src/rsrr/checks/ef_cves.py
@@ -1,0 +1,38 @@
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ..base import BaseCheck
+
+GL_API_BASE = "https://gitlab.eclipse.org/api/v4"
+GL_PROJECT = "eclipsefdn/security/vulnerabilities"
+
+
+class Check(BaseCheck):
+    name = "EF CVEs"
+    comment = (
+        "Returns advisories from the EF vulnerabilities repo matching the project ID"
+    )
+
+    async def run(self) -> list[dict[str, Any]]:
+        if not self.ctx.ef_project_id:
+            raise ValueError("--ef-project-id is required for this check")
+
+        headers: dict[str, str] = {}
+        if self.ctx.gl_token:
+            headers["PRIVATE-TOKEN"] = self.ctx.gl_token
+
+        encoded_project = quote(GL_PROJECT, safe="")
+        encoded_file = quote("advisories.json", safe="")
+
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                f"{GL_API_BASE}/projects/{encoded_project}/repository/files/{encoded_file}/raw",
+                params={"ref": "main"},
+                headers=headers,
+            )
+        response.raise_for_status()
+
+        advisories: list[dict[str, Any]] = response.json()
+        return [a for a in advisories if a.get("project") == self.ctx.ef_project_id]

--- a/src/rsrr/checks/ef_inactive_committers.py
+++ b/src/rsrr/checks/ef_inactive_committers.py
@@ -1,0 +1,57 @@
+import logging
+
+from ..base import BaseCheck
+
+logger = logging.getLogger(__name__)
+
+
+class Check(BaseCheck):
+    name = "EF Inactive Committers"
+    comment = "Lists EF committers whose GitHub handle has no commits in the past year"
+    depends_on = ["ef_committers", "gh_repo_commit_activity"]
+
+    async def run(self) -> list[dict]:
+        committers = self.ctx.data["ef_committers"]
+        activity = self.ctx.data["gh_repo_commit_activity"]
+
+        # Collect all GitHub logins that have committed in the past year
+        active_logins: set[str] = set()
+        for repo_data in activity.values():
+            if not isinstance(repo_data, dict):
+                continue
+            for committer in repo_data.get("committers", []):
+                login = committer.get("login", "")
+                if login:
+                    active_logins.add(login.lower())
+
+        inactive = []
+        for committer in committers:
+            first_name = committer.get("first_name", "")
+            last_name = committer.get("last_name", "")
+            handle = committer.get("github_handle", "")
+
+            if not handle:
+                logger.warning(
+                    f"EF committer {first_name} {last_name} has no GitHub handle"
+                )
+                inactive.append(
+                    {
+                        "first_name": first_name,
+                        "last_name": last_name,
+                        "github_handle": "",
+                        "reason": "no_github_handle",
+                    }
+                )
+                continue
+
+            if handle.lower() not in active_logins:
+                inactive.append(
+                    {
+                        "first_name": first_name,
+                        "last_name": last_name,
+                        "github_handle": handle,
+                        "reason": "no_recent_commits",
+                    }
+                )
+
+        return inactive

--- a/src/rsrr/checks/ef_project.py
+++ b/src/rsrr/checks/ef_project.py
@@ -1,7 +1,7 @@
 import httpx
 from typing import Any
 
-from .base import BaseCheck
+from ..base import BaseCheck
 
 
 class Check(BaseCheck):
@@ -17,4 +17,10 @@ class Check(BaseCheck):
                 f"https://projects.eclipse.org/api/projects/{self.ctx.ef_project_id_normalized}",
             )
         response.raise_for_status()
-        return response.json()
+        project = response.json()[0]
+
+        return {
+            "committers": project["committers"],
+            "github": project["github"],
+            "github_repos": project["github_repos"],
+        }

--- a/src/rsrr/checks/gh_alerts.py
+++ b/src/rsrr/checks/gh_alerts.py
@@ -1,0 +1,33 @@
+from typing import Any
+
+from ..base import BaseCheck
+
+
+class Check(BaseCheck):
+    name = "GitHub Dependabot Alerts"
+    comment = "Fetches all Dependabot alerts for a GitHub repo"
+
+    async def run(self) -> list[dict[str, Any]]:
+        if not self.ctx.gh_repo:
+            raise ValueError("--gh-repo is required for this check")
+
+        owner, repo = self.ctx.gh_repo.split("/", 1)
+        alerts: list[dict[str, Any]] = []
+        url = (
+            f"https://api.github.com/repos/{owner}/{repo}"
+            f"/dependabot/alerts?per_page=100"
+        )
+
+        while url:
+            response = await self.ctx.github_get(url)
+            alerts.extend(response.json())
+            url = response.links.get("next", {}).get("url")
+
+        return [
+            {
+                "html_url": a["html_url"],
+                "state": a["state"],
+                "created_at": a["created_at"],
+            }
+            for a in alerts
+        ]

--- a/src/rsrr/checks/gh_default_security_policy.py
+++ b/src/rsrr/checks/gh_default_security_policy.py
@@ -1,0 +1,39 @@
+import logging
+from urllib.parse import urlparse
+
+import httpx
+
+from ..base import BaseCheck
+
+logger = logging.getLogger(__name__)
+
+
+class Check(BaseCheck):
+    name = "GitHub Default Security Policy"
+    comment = "Checks if each GitHub organization has a default SECURITY.md in its .github repo"
+    depends_on = ["gh_repos"]
+
+    async def run(self) -> dict[str, bool]:
+        repos = self.ctx.data["gh_repos"]
+
+        # Extract unique orgs from repo URLs
+        orgs: set[str] = set()
+        for url in repos:
+            parts = urlparse(url).path.strip("/").split("/")
+            if len(parts) >= 2:
+                orgs.add(parts[0])
+
+        results = {}
+        for org in sorted(orgs):
+            try:
+                await self.ctx.github_get(
+                    f"https://api.github.com/repos/{org}/.github/contents/SECURITY.md",
+                )
+                results[org] = True
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code == 404:
+                    results[org] = False
+                else:
+                    raise
+
+        return results

--- a/src/rsrr/checks/gh_has_dot_github_repo.py
+++ b/src/rsrr/checks/gh_has_dot_github_repo.py
@@ -1,0 +1,39 @@
+import logging
+from urllib.parse import urlparse
+
+import httpx
+
+from ..base import BaseCheck
+
+logger = logging.getLogger(__name__)
+
+
+class Check(BaseCheck):
+    name = "GitHub .github Repo"
+    comment = "Checks if each GitHub organization has a .github repo"
+    depends_on = ["gh_repos"]
+
+    async def run(self) -> dict[str, bool]:
+        repos = self.ctx.data["gh_repos"]
+
+        # Extract unique orgs from repo URLs
+        orgs: set[str] = set()
+        for url in repos:
+            parts = urlparse(url).path.strip("/").split("/")
+            if len(parts) >= 2:
+                orgs.add(parts[0])
+
+        results = {}
+        for org in sorted(orgs):
+            try:
+                await self.ctx.github_get(
+                    f"https://api.github.com/repos/{org}/.github",
+                )
+                results[org] = True
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code == 404:
+                    results[org] = False
+                else:
+                    raise
+
+        return results

--- a/src/rsrr/checks/gh_private_vulnerability_reporting.py
+++ b/src/rsrr/checks/gh_private_vulnerability_reporting.py
@@ -1,0 +1,16 @@
+from ..base import BaseCheck
+
+
+class Check(BaseCheck):
+    name = "GitHub Private Vulnerability Reporting"
+    comment = "Checks if private vulnerability reporting is enabled for a GitHub repo"
+
+    async def run(self) -> bool:
+        if not self.ctx.gh_repo:
+            raise ValueError("--gh-repo is required for this check")
+
+        owner, repo = self.ctx.gh_repo.split("/", 1)
+        response = await self.ctx.github_get(
+            f"https://api.github.com/repos/{owner}/{repo}/private-vulnerability-reporting",
+        )
+        return response.json()["enabled"]

--- a/src/rsrr/checks/gh_releases.py
+++ b/src/rsrr/checks/gh_releases.py
@@ -1,0 +1,39 @@
+from collections import Counter
+from typing import Any
+
+from ..base import BaseCheck
+
+
+class Check(BaseCheck):
+    name = "GitHub Releases"
+    comment = "Fetches all releases and counts releases per year"
+
+    async def run(self) -> dict[str, Any]:
+        if not self.ctx.gh_repo:
+            raise ValueError("--gh-repo is required for this check")
+
+        owner, repo = self.ctx.gh_repo.split("/", 1)
+        releases: list[dict[str, Any]] = []
+        url = f"https://api.github.com/repos/{owner}/{repo}/releases?per_page=100"
+
+        while url:
+            response = await self.ctx.github_get(url)
+            releases.extend(response.json())
+            url = response.links.get("next", {}).get("url")
+
+        year_counts: Counter[str] = Counter()
+        for release in releases:
+            published = release.get("published_at") or release.get("created_at", "")
+            if published:
+                year_counts[published[:4]] += 1
+
+        return {
+            "releases": [
+                {
+                    "html_url": r["html_url"],
+                    "published_at": r["published_at"],
+                }
+                for r in releases
+            ],
+            "releases_per_year": dict(sorted(year_counts.items())),
+        }

--- a/src/rsrr/checks/gh_repo_clone.py
+++ b/src/rsrr/checks/gh_repo_clone.py
@@ -1,0 +1,32 @@
+import asyncio
+import tempfile
+
+from ..base import BaseCheck
+
+
+class Check(BaseCheck):
+    name = "GitHub Repo Clone"
+    comment = "Clones the GitHub repo into a temporary directory"
+
+    async def run(self) -> str:
+        if not self.ctx.gh_repo:
+            raise ValueError("--gh-repo is required for this check")
+
+        tmp_dir = tempfile.mkdtemp(prefix="rsrr-clone-")
+        url = f"https://github.com/{self.ctx.gh_repo}.git"
+
+        proc = await asyncio.create_subprocess_exec(
+            "git",
+            "clone",
+            "--depth",
+            "1",
+            url,
+            tmp_dir,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        _, stderr = await proc.communicate()
+        if proc.returncode != 0:
+            raise RuntimeError(f"git clone failed: {stderr.decode().strip()}")
+
+        return tmp_dir

--- a/src/rsrr/checks/gh_repo_commit_activity.py
+++ b/src/rsrr/checks/gh_repo_commit_activity.py
@@ -1,0 +1,60 @@
+import logging
+from datetime import datetime, timedelta, timezone
+from urllib.parse import urlparse
+
+import httpx
+
+from ..base import BaseCheck
+
+logger = logging.getLogger(__name__)
+
+
+class Check(BaseCheck):
+    name = "GitHub Repo Commit Activity"
+    comment = "Returns commit count and committers in the past year for each repo"
+    depends_on = ["gh_repos"]
+
+    async def run(self) -> dict[str, dict]:
+        repos = self.ctx.data["gh_repos"]
+        since = (datetime.now(timezone.utc) - timedelta(days=365)).isoformat()
+
+        results = {}
+        for url in repos:
+            parts = urlparse(url).path.strip("/").split("/")
+            if len(parts) < 2:
+                continue
+            owner, repo = parts[0], parts[1]
+
+            try:
+                total = 0
+                committers: dict[str, dict] = {}
+                page = 1
+                while True:
+                    response = await self.ctx.github_get(
+                        f"https://api.github.com/repos/{owner}/{repo}/commits"
+                        f"?since={since}&per_page=100&page={page}",
+                    )
+                    commits = response.json()
+                    if not commits:
+                        break
+                    total += len(commits)
+                    for commit in commits:
+                        info = commit.get("commit", {}).get("author", {})
+                        name = info.get("name", "")
+                        email = info.get("email", "")
+                        login = (commit.get("author") or {}).get("login", "")
+                        if email and email not in committers:
+                            committers[email] = {"name": name, "login": login}
+                    page += 1
+                results[url] = {
+                    "commit_count": total,
+                    "committers": [
+                        {"name": c["name"], "email": email, "login": c["login"]}
+                        for email, c in committers.items()
+                    ],
+                }
+            except httpx.HTTPStatusError as e:
+                logger.error(f"{owner}/{repo}: {e}")
+                results[url] = {"commit_count": -1, "committers": []}
+
+        return results

--- a/src/rsrr/checks/gh_repos.py
+++ b/src/rsrr/checks/gh_repos.py
@@ -1,0 +1,51 @@
+import logging
+
+from ..base import BaseCheck
+
+logger = logging.getLogger(__name__)
+
+
+class Check(BaseCheck):
+    name = "GitHub Repos"
+    comment = "List all GitHub repos for the project"
+    depends_on = ["ef_project"]
+
+    async def run(self) -> list[str]:
+        project = self.ctx.data["ef_project"]
+        ignored = set(project.get("github", {}).get("ignored_repos", []))
+
+        # Collect explicitly listed repos
+        repos: dict[str, None] = {}
+        for entry in project.get("github_repos", []):
+            url = entry.get("url", "").rstrip("/")
+            if url:
+                repos[url] = None
+
+        # Query GitHub org for all public repos
+        org = project.get("github", {}).get("org", "")
+        if org:
+            page = 1
+            while True:
+                response = await self.ctx.github_get(
+                    f"https://api.github.com/orgs/{org}/repos"
+                    f"?type=public&per_page=100&page={page}",
+                )
+                org_repos = response.json()
+                if not org_repos:
+                    break
+                for repo in org_repos:
+                    url = repo.get("html_url", "").rstrip("/")
+                    if url:
+                        repos[url] = None
+                page += 1
+
+        # Filter out ignored repos
+        result = []
+        for url in repos:
+            repo_name = url.rsplit("/", 1)[-1]
+            if repo_name in ignored:
+                logger.info(f"Ignoring repo: {url}")
+                continue
+            result.append(url)
+
+        return result

--- a/src/rsrr/checks/gh_scorecard.py
+++ b/src/rsrr/checks/gh_scorecard.py
@@ -1,0 +1,30 @@
+import asyncio
+import os
+
+from ..base import BaseCheck
+
+
+class Check(BaseCheck):
+    name = "OpenSSF Scorecard"
+    comment = "Runs OpenSSF Scorecard against a GitHub repo"
+
+    async def run(self) -> str:
+        if not self.ctx.gh_repo or not self.ctx.gh_token:
+            raise ValueError("--gh-repo and --gh-token are required for this check")
+
+        env = os.environ.copy()
+        env["GITHUB_AUTH_TOKEN"] = self.ctx.gh_token
+
+        proc = await asyncio.create_subprocess_exec(
+            "scorecard",
+            f"--repo=github.com/{self.ctx.gh_repo}",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        stdout, stderr = await proc.communicate()
+
+        if proc.returncode != 0:
+            raise RuntimeError(f"scorecard failed: {stderr.decode().strip()}")
+
+        return stdout.strip().decode().splitlines()

--- a/src/rsrr/checks/gh_security_advisories.py
+++ b/src/rsrr/checks/gh_security_advisories.py
@@ -1,0 +1,35 @@
+from typing import Any
+
+from ..base import BaseCheck
+
+
+class Check(BaseCheck):
+    name = "GitHub Security Advisories"
+    comment = "Fetches all security advisories for a GitHub repo"
+
+    async def run(self) -> list[dict[str, Any]]:
+        if not self.ctx.gh_repo:
+            raise ValueError("--gh-repo is required for this check")
+
+        owner, repo = self.ctx.gh_repo.split("/", 1)
+        advisories: list[dict[str, Any]] = []
+        url = (
+            f"https://api.github.com/repos/{owner}/{repo}"
+            f"/security-advisories?per_page=100"
+        )
+
+        while url:
+            response = await self.ctx.github_get(url)
+            advisories.extend(response.json())
+            url = response.links.get("next", {}).get("url")
+
+        return [
+            {
+                "html_url": a["html_url"],
+                "summary": a["summary"],
+                "severity": a["severity"],
+                "created_at": a["created_at"],
+                "published_at": a["published_at"],
+            }
+            for a in advisories
+        ]

--- a/src/rsrr/checks/gh_zizmor.py
+++ b/src/rsrr/checks/gh_zizmor.py
@@ -1,0 +1,32 @@
+import asyncio
+import os
+from typing import Any
+
+from ..base import BaseCheck
+
+
+class Check(BaseCheck):
+    name = "Zizmor"
+    comment = "Runs zizmor GitHub Actions security audit on a GitHub repo"
+
+    async def run(self) -> list[dict[str, Any]]:
+        if not self.ctx.gh_repo or not self.ctx.gh_token:
+            raise ValueError("--gh-repo and --gh-token are required for this check")
+
+        env = os.environ.copy()
+        env["GH_TOKEN"] = self.ctx.gh_token
+
+        proc = await asyncio.create_subprocess_exec(
+            "zizmor",
+            self.ctx.gh_repo,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        stdout, stderr = await proc.communicate()
+
+        # See https://docs.zizmor.sh/usage/#exit-codes
+        if proc.returncode > 0 and proc.returncode < 11:
+            raise RuntimeError(f"zizmor failed: {stderr.decode().strip()}")
+
+        return stdout.strip().decode().splitlines()

--- a/src/rsrr/checks/gl_vulnerability_reports.py
+++ b/src/rsrr/checks/gl_vulnerability_reports.py
@@ -1,0 +1,58 @@
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ..base import BaseCheck
+
+GL_PROJECT = "security/vulnerability-reports"
+GL_API_BASE = "https://gitlab.eclipse.org/api/v4"
+
+
+class Check(BaseCheck):
+    name = "GitLab Vulnerability Reports"
+    comment = (
+        "Searches GitLab vulnerability-reports project for issues matching keywords"
+    )
+
+    async def run(self) -> list[dict[str, Any]]:
+        if not self.ctx.gl_vuln_kw:
+            raise ValueError("--gl-vuln-kw is required for this check")
+
+        words = self.ctx.gl_vuln_kw
+
+        headers: dict[str, str] = {}
+        if self.ctx.gl_token:
+            headers["PRIVATE-TOKEN"] = self.ctx.gl_token
+
+        encoded_project = quote(GL_PROJECT, safe="")
+        seen_ids: set[int] = set()
+        results: list[dict[str, Any]] = []
+
+        async with httpx.AsyncClient() as client:
+            for word in words:
+                page = 1
+                while True:
+                    response = await client.get(
+                        f"{GL_API_BASE}/projects/{encoded_project}/issues",
+                        params={
+                            "search": word,
+                            "in": "title,description",
+                            "per_page": 100,
+                            "page": page,
+                        },
+                        headers=headers,
+                    )
+                    response.raise_for_status()
+                    issues = response.json()
+                    if not issues:
+                        break
+                    for issue in issues:
+                        if issue["id"] not in seen_ids:
+                            seen_ids.add(issue["id"])
+                            results.append(
+                                {"title": issue["title"], "web_url": issue["web_url"]}
+                            )
+                    page += 1
+
+        return results

--- a/src/rsrr/cli.py
+++ b/src/rsrr/cli.py
@@ -19,10 +19,18 @@ def get_all_checks() -> dict:
 
 
 @click.group(invoke_without_command=True)
+@click.option("-v", "--verbose", is_flag=True, help="Enable info logging")
 @click.pass_context
-def main(ctx: click.Context) -> None:
+def main(ctx: click.Context, verbose: bool) -> None:
     """Rapid Security Review Runner -- Runs an extensible set of checks for
     Eclipse Foundation Rapid Security Reviews."""
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+    pkg_logger = logging.getLogger("rsrr")
+    pkg_logger.handlers.clear()
+    pkg_logger.addHandler(handler)
+    pkg_logger.setLevel(logging.INFO if verbose else logging.WARNING)
+    pkg_logger.propagate = False
 
     if ctx.invoked_subcommand is None:
         click.echo(ctx.get_help())
@@ -46,20 +54,77 @@ def list_cmd() -> None:
     default=None,
     help="Eclipse Foundation project ID",
 )
+@click.option(
+    "--gh-repo",
+    default=None,
+    help="GitHub repository in owner/repo format",
+)
+@click.option(
+    "--gh-token",
+    envvar="GH_TOKEN",
+    default=None,
+    help="GitHub API token (or set GH_TOKEN env var)",
+)
+@click.option(
+    "--gl-token",
+    envvar="GL_TOKEN",
+    default=None,
+    help="GitLab API token (or set GL_TOKEN env var)",
+)
+@click.option(
+    "--gl-vuln-kw",
+    multiple=True,
+    help="Keywords to search in GitLab vulnerability reports (repeatable)",
+)
+@click.option(
+    "--ctx-data",
+    type=click.Path(dir_okay=False),
+    default=None,
+    help="JSON file to read/write context data (results are merged back into this file)",
+)
 def run(
     checks: tuple[str, ...],
     ef_project_id: str | None,
+    gh_repo: str | None,
+    gh_token: str | None,
+    gl_token: str | None,
+    gl_vuln_kw: tuple[str, ...],
+    ctx_data: str | None,
 ) -> None:
     """Run checks.
 
     If CHECK arguments are provided, only those checks are run.
     Otherwise, all available checks are run.
+
+    When --ctx-data is given, existing results are loaded from the file and
+    checks with entries already present are skipped. After running, all
+    results (old and new) are written back to the same file.
     """
-    ctx = Context(ef_project_id=ef_project_id)
-    sys.exit(asyncio.run(run_async(checks, ctx)))
+    data = {}
+    if ctx_data is not None and Path(ctx_data).exists():
+        try:
+            with open(ctx_data) as f:
+                data = json.load(f)
+        except json.JSONDecodeError as e:
+            click.echo(f"Invalid JSON in {ctx_data}: {e}", err=True)
+            sys.exit(1)
+        if not isinstance(data, dict):
+            click.echo("--ctx-data file must contain a JSON object", err=True)
+            sys.exit(1)
+    ctx = Context(
+        ef_project_id=ef_project_id,
+        gh_repo=gh_repo,
+        gh_token=gh_token,
+        gl_token=gl_token,
+        gl_vuln_kw=gl_vuln_kw,
+        data=data,
+    )
+    sys.exit(asyncio.run(run_async(checks, ctx, ctx_data)))
 
 
-async def run_async(checks: tuple[str, ...], ctx: Context) -> int:
+async def run_async(
+    checks: tuple[str, ...], ctx: Context, ctx_data_path: str | None
+) -> int:
     all_checks = get_all_checks()
 
     # Filter checks if specific ones requested
@@ -82,7 +147,12 @@ async def run_async(checks: tuple[str, ...], ctx: Context) -> int:
     except ValueError as e:
         logger.error(e)
 
-    click.echo(json.dumps(ctx.data))
+    if ctx_data_path is not None:
+        with open(ctx_data_path, "w") as f:
+            json.dump(ctx.data, f, indent=2)
+            f.write("\n")
+    else:
+        click.echo(json.dumps(ctx.data, indent=2))
 
     return 0
 

--- a/src/rsrr/runner.py
+++ b/src/rsrr/runner.py
@@ -2,15 +2,28 @@ import asyncio
 import importlib
 import pkgutil
 import logging
+import time
 from pathlib import Path
 
-from .checks import BaseCheck, Context
+import click
+
+from .base import BaseCheck, Context
 
 logger = logging.getLogger(__name__)
 
 
-def discover_checks(package_path: Path) -> dict[str, type[BaseCheck]]:
-    """Discover all check implementations in the checks package.
+def discover_checks(
+    package_path: Path, package: str = "rsrr.checks"
+) -> dict[str, type[BaseCheck]]:
+    """Discover all check implementations in a directory.
+
+    Loads each .py module (except base.py and __init__.py) from package_path
+    and collects those that export a Check class inheriting from BaseCheck.
+
+    Args:
+        package_path: Directory to scan for check modules.
+        package: Dotted package name for the modules. Relative imports inside
+            check files are resolved against this package.
 
     Returns a dict mapping check IDs (module names) to check classes.
     """
@@ -20,7 +33,7 @@ def discover_checks(package_path: Path) -> dict[str, type[BaseCheck]]:
         if module_info.name in ("base", "__init__"):
             continue
 
-        module = importlib.import_module(f".checks.{module_info.name}", package="rsrr")
+        module = importlib.import_module(f".{module_info.name}", package=package)
 
         if hasattr(module, "Check") and issubclass(module.Check, BaseCheck):
             checks[module_info.name] = module.Check
@@ -28,27 +41,60 @@ def discover_checks(package_path: Path) -> dict[str, type[BaseCheck]]:
     return checks
 
 
-async def run_check(check_id: str, check_cls: type[BaseCheck], ctx: Context):
-    """Run a single check and return the result."""
+async def run_check(check_id: str, check_cls: type[BaseCheck], ctx: Context) -> bool:
+    """Run a single check and return whether it succeeded."""
+    click.echo(f"  ... {check_id}", err=True)
+    start = time.monotonic()
     check = check_cls(ctx)
     try:
         value = await check.run()
         ctx.data[check_id] = value
-
+        click.echo(f"   ok {check_id} ({time.monotonic() - start:.1f}s)", err=True)
+        return True
     except Exception as e:
         logger.error(f"{check_id}: {e}")
+        click.echo(f"  err {check_id} ({time.monotonic() - start:.1f}s)", err=True)
+        return False
 
 
 async def run_checks(checks: dict[str, type[BaseCheck]], ctx: Context):
     """Run all checks respecting dependencies.
 
     Checks are run in waves. Each wave runs checks whose dependencies have
-    all completed.
+    all completed. If a check fails, all checks that depend on it (directly
+    or transitively) are skipped. Checks whose results are already present
+    in ``ctx.data`` are treated as completed and not re-run (this satisfies
+    dependencies on them too).
     """
+    # Treat checks with pre-populated data as already completed
     completed: set[str] = set()
-    pending = dict(checks)
+    failed: set[str] = set()
+    pending = {}
+    for check_id, check_cls in checks.items():
+        if check_id in ctx.data:
+            logger.info(f"{check_id}: skipped (already in context data)")
+            completed.add(check_id)
+        else:
+            pending[check_id] = check_cls
 
     while pending:
+        # Skip checks that depend on a failed check (loop for transitive deps)
+        while True:
+            skipped = {
+                check_id
+                for check_id, check_cls in pending.items()
+                if any(dep in failed for dep in check_cls.depends_on)
+            }
+            if not skipped:
+                break
+            for check_id in skipped:
+                logger.warning(f"{check_id}: skipped (dependency failed)")
+                failed.add(check_id)
+                del pending[check_id]
+
+        if not pending:
+            break
+
         # Find checks whose dependencies are all completed
         ready = {
             check_id: check_cls
@@ -67,9 +113,12 @@ async def run_checks(checks: dict[str, type[BaseCheck]], ctx: Context):
         tasks = [
             run_check(check_id, check_cls, ctx) for check_id, check_cls in ready.items()
         ]
-        wave_results = await asyncio.gather(*tasks)
+        results = await asyncio.gather(*tasks)
 
-        # Record results and mark as completed
-        for check_id, result in zip(ready.keys(), wave_results):
-            completed.add(check_id)
+        # Record results and mark as completed or failed
+        for check_id, succeeded in zip(ready.keys(), results):
+            if succeeded:
+                completed.add(check_id)
+            else:
+                failed.add(check_id)
             del pending[check_id]

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,52 @@
+from unittest.mock import AsyncMock, patch, MagicMock
+
+import pytest
+
+from rsrr.base import Context
+
+
+@pytest.mark.asyncio
+async def test_github_get_with_token():
+    ctx = Context(gh_token="test-token")
+
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_response
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("rsrr.base.httpx.AsyncClient", return_value=mock_client):
+        response = await ctx.github_get("https://api.github.com/repos/foo/bar")
+
+    assert response is mock_response
+    mock_client.get.assert_called_once_with(
+        "https://api.github.com/repos/foo/bar",
+        headers={
+            "Accept": "application/vnd.github.v3+json",
+            "Authorization": "Bearer test-token",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_github_get_without_token():
+    ctx = Context()
+
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_response
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("rsrr.base.httpx.AsyncClient", return_value=mock_client):
+        response = await ctx.github_get("https://api.github.com/repos/foo/bar")
+
+    assert response is mock_response
+    mock_client.get.assert_called_once_with(
+        "https://api.github.com/repos/foo/bar",
+        headers={"Accept": "application/vnd.github.v3+json"},
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,218 @@
+from typing import Any
+from unittest.mock import patch
+import json
+
+from click.testing import CliRunner
+
+from rsrr.base import BaseCheck, Context
+from rsrr.cli import main
+
+
+# -- Fake checks --
+
+
+class FakeCheckA(BaseCheck):
+    name = "Check A"
+    comment = "First fake check"
+
+    async def run(self) -> Any:
+        return "result_a"
+
+
+class FakeCheckB(BaseCheck):
+    name = "Check B"
+    comment = "Second fake check"
+
+    async def run(self) -> Any:
+        return "result_b"
+
+
+FAKE_CHECKS = {"check_a": FakeCheckA, "check_b": FakeCheckB}
+
+
+def _patch_checks(checks=None):
+    if checks is None:
+        checks = FAKE_CHECKS
+    return patch("rsrr.cli.get_all_checks", return_value=checks)
+
+
+# -- Tests --
+
+
+def test_main_no_subcommand_shows_help():
+    runner = CliRunner()
+    result = runner.invoke(main, [])
+    assert result.exit_code == 0
+    assert "Rapid Security Review Runner" in result.output
+
+
+def test_verbose_enables_info_logging():
+    """The -v flag sets the rsrr package logger to INFO."""
+    import logging as _logging
+
+    with _patch_checks():
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["-v", "run", "--ef-project-id", "test.project"],
+        )
+
+    assert result.exit_code == 0
+    assert _logging.getLogger("rsrr").level == _logging.INFO
+
+
+def test_list_shows_checks():
+    with _patch_checks():
+        runner = CliRunner()
+        result = runner.invoke(main, ["list"])
+    assert result.exit_code == 0
+    assert "check_a" in result.output
+    assert "Check A" in result.output
+    assert "check_b" in result.output
+
+
+def test_run_all_checks_to_stdout():
+    """Without --ctx-data, results are printed to stdout."""
+    with _patch_checks():
+        runner = CliRunner()
+        result = runner.invoke(main, ["run", "--ef-project-id", "test.project"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["check_a"] == "result_a"
+    assert data["check_b"] == "result_b"
+
+
+def test_run_all_checks_to_file(tmp_path):
+    """With --ctx-data, results are written to the file."""
+    ctx_file = tmp_path / "results.json"
+
+    with _patch_checks():
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["run", "--ef-project-id", "test.project", "--ctx-data", str(ctx_file)],
+        )
+
+    assert result.exit_code == 0
+    data = json.loads(ctx_file.read_text())
+    assert data["check_a"] == "result_a"
+    assert data["check_b"] == "result_b"
+
+
+def test_run_specific_check():
+    with _patch_checks():
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["run", "--ef-project-id", "test.project", "check_a"]
+        )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["check_a"] == "result_a"
+    assert "check_b" not in data
+
+
+def test_run_unknown_check():
+    with _patch_checks():
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["run", "--ef-project-id", "test.project", "nonexistent"]
+        )
+
+    assert result.exit_code == 1
+    assert "Unknown checks" in result.output
+    assert "nonexistent" in result.output
+
+
+def test_run_with_ctx_data_incremental(tmp_path):
+    """--ctx-data reads existing data and writes merged results back."""
+    ctx_file = tmp_path / "ctx.json"
+    ctx_file.write_text('{"check_a": "cached"}')
+
+    with _patch_checks():
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["run", "--ef-project-id", "test.project", "--ctx-data", str(ctx_file)],
+        )
+
+    assert result.exit_code == 0
+    data = json.loads(ctx_file.read_text())
+    assert data["check_a"] == "cached"
+    assert data["check_b"] == "result_b"
+
+
+def test_run_with_invalid_ctx_data(tmp_path):
+    ctx_file = tmp_path / "bad.json"
+    ctx_file.write_text("not-json")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["run", "--ef-project-id", "test.project", "--ctx-data", str(ctx_file)]
+    )
+    assert result.exit_code == 1
+    assert "Invalid JSON" in result.output
+
+
+def test_run_with_non_object_ctx_data(tmp_path):
+    ctx_file = tmp_path / "array.json"
+    ctx_file.write_text("[1, 2]")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["run", "--ef-project-id", "test.project", "--ctx-data", str(ctx_file)]
+    )
+    assert result.exit_code == 1
+    assert "--ctx-data file must contain a JSON object" in result.output
+
+
+def test_run_with_gh_token():
+    """--gh-token is passed through to Context."""
+    with _patch_checks(), patch("rsrr.cli.Context") as mock_ctx_cls:
+        mock_ctx_cls.return_value = Context(gh_token="tok123")
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["run", "--ef-project-id", "test.project", "--gh-token", "tok123"],
+        )
+
+    assert result.exit_code == 0
+    mock_ctx_cls.assert_called_once_with(
+        ef_project_id="test.project",
+        gh_repo=None,
+        gh_token="tok123",
+        gl_token=None,
+        gl_vuln_kw=(),
+        data={},
+    )
+
+
+def test_run_gh_token_from_env():
+    """GH_TOKEN env var is used when --gh-token is not provided."""
+    with _patch_checks(), patch("rsrr.cli.Context") as mock_ctx_cls:
+        mock_ctx_cls.return_value = Context(gh_token="env-token")
+        runner = CliRunner(env={"GH_TOKEN": "env-token"})
+        result = runner.invoke(
+            main,
+            ["run", "--ef-project-id", "test.project"],
+        )
+
+    assert result.exit_code == 0
+    mock_ctx_cls.assert_called_once_with(
+        ef_project_id="test.project",
+        gh_repo=None,
+        gh_token="env-token",
+        gl_token=None,
+        gl_vuln_kw=(),
+        data={},
+    )
+
+
+def test_run_no_checks_available():
+    with _patch_checks(checks={}):
+        runner = CliRunner()
+        result = runner.invoke(main, ["run", "--ef-project-id", "test.project"])
+
+    assert result.exit_code == 1
+    assert "No checks to run" in result.output

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,259 @@
+import sys
+import textwrap
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from rsrr.base import BaseCheck, Context
+from rsrr.runner import discover_checks, run_check, run_checks
+
+
+# -- Fake checks used as fixtures --
+
+
+class PassingCheck(BaseCheck):
+    name = "Passing"
+    comment = "Always succeeds"
+
+    async def run(self) -> Any:
+        return {"ok": True}
+
+
+class FailingCheck(BaseCheck):
+    name = "Failing"
+    comment = "Always raises"
+
+    async def run(self) -> Any:
+        raise RuntimeError("boom")
+
+
+class DependentCheck(BaseCheck):
+    name = "Dependent"
+    comment = "Depends on passing"
+    depends_on = ["passing"]
+
+    async def run(self) -> Any:
+        return {"upstream": self.ctx.data["passing"]}
+
+
+class CircularA(BaseCheck):
+    name = "CircularA"
+    comment = ""
+    depends_on = ["circular_b"]
+
+    async def run(self) -> Any:
+        return None
+
+
+class CircularB(BaseCheck):
+    name = "CircularB"
+    comment = ""
+    depends_on = ["circular_a"]
+
+    async def run(self) -> Any:
+        return None
+
+
+# -- discover_checks --
+
+
+def test_discover_checks(tmp_path: Path):
+    """Valid check modules are discovered; non-check modules are skipped."""
+    # Valid check module
+    (tmp_path / "good_check.py").write_text(
+        textwrap.dedent("""\
+            from rsrr.base import BaseCheck
+            class Check(BaseCheck):
+                name = "Good"
+                comment = "A good check"
+                async def run(self):
+                    return True
+        """)
+    )
+    # Module without a Check class — should be skipped
+    (tmp_path / "no_check.py").write_text("x = 1\n")
+    # __init__.py and base.py — should be skipped
+    (tmp_path / "__init__.py").write_text("")
+    (tmp_path / "base.py").write_text("")
+
+    # Register a fake parent package so importlib.import_module can resolve
+    # relative imports against it.
+    pkg_name = "test_discover_checks"
+    pkg = types.ModuleType(pkg_name)
+    pkg.__path__ = [str(tmp_path)]
+    pkg.__package__ = pkg_name
+    sys.modules[pkg_name] = pkg
+    try:
+        checks = discover_checks(tmp_path, package=pkg_name)
+    finally:
+        # Clean up sys.modules
+        to_remove = [k for k in sys.modules if k.startswith(pkg_name)]
+        for k in to_remove:
+            del sys.modules[k]
+
+    assert "good_check" in checks
+    assert "no_check" not in checks
+    assert "__init__" not in checks
+    assert "base" not in checks
+
+
+# -- run_check --
+
+
+@pytest.mark.asyncio
+async def test_run_check_stores_result():
+    ctx = Context()
+    assert await run_check("passing", PassingCheck, ctx) is True
+    assert ctx.data["passing"] == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_run_check_exception_handled():
+    """A failing check should not propagate the exception."""
+    ctx = Context()
+    assert await run_check("failing", FailingCheck, ctx) is False
+    assert "failing" not in ctx.data
+
+
+# -- run_checks --
+
+
+@pytest.mark.asyncio
+async def test_run_checks_respects_dependencies():
+    """DependentCheck runs after PassingCheck and can read its result."""
+    checks = {
+        "passing": PassingCheck,
+        "dependent": DependentCheck,
+    }
+    ctx = Context()
+    await run_checks(checks, ctx)
+
+    assert ctx.data["passing"] == {"ok": True}
+    assert ctx.data["dependent"] == {"upstream": {"ok": True}}
+
+
+@pytest.mark.asyncio
+async def test_run_checks_parallel_wave():
+    """Independent checks run in the same wave (both complete)."""
+    order = []
+
+    class A(BaseCheck):
+        name = "A"
+        comment = ""
+
+        async def run(self) -> Any:
+            order.append("a")
+            return "a"
+
+    class B(BaseCheck):
+        name = "B"
+        comment = ""
+
+        async def run(self) -> Any:
+            order.append("b")
+            return "b"
+
+    ctx = Context()
+    await run_checks({"a": A, "b": B}, ctx)
+
+    assert set(order) == {"a", "b"}
+    assert ctx.data["a"] == "a"
+    assert ctx.data["b"] == "b"
+
+
+@pytest.mark.asyncio
+async def test_run_checks_skips_dependent_on_failure():
+    """If a check fails, checks that depend on it are skipped."""
+
+    class DependsOnFailing(BaseCheck):
+        name = "DependsOnFailing"
+        comment = ""
+        depends_on = ["failing"]
+
+        async def run(self) -> Any:
+            return "should not run"
+
+    ctx = Context()
+    await run_checks(
+        {"failing": FailingCheck, "depends_on_failing": DependsOnFailing}, ctx
+    )
+
+    assert "failing" not in ctx.data
+    assert "depends_on_failing" not in ctx.data
+
+
+@pytest.mark.asyncio
+async def test_run_checks_skips_transitive_dependents():
+    """Transitive dependents of a failed check are also skipped."""
+
+    class Middle(BaseCheck):
+        name = "Middle"
+        comment = ""
+        depends_on = ["failing"]
+
+        async def run(self) -> Any:
+            return "middle"
+
+    class Leaf(BaseCheck):
+        name = "Leaf"
+        comment = ""
+        depends_on = ["middle"]
+
+        async def run(self) -> Any:
+            return "leaf"
+
+    ctx = Context()
+    await run_checks({"failing": FailingCheck, "middle": Middle, "leaf": Leaf}, ctx)
+
+    assert "failing" not in ctx.data
+    assert "middle" not in ctx.data
+    assert "leaf" not in ctx.data
+
+
+@pytest.mark.asyncio
+async def test_run_checks_independent_check_unaffected_by_failure():
+    """A check with no dependency on the failed check still runs."""
+    ctx = Context()
+    await run_checks({"failing": FailingCheck, "passing": PassingCheck}, ctx)
+
+    assert "failing" not in ctx.data
+    assert ctx.data["passing"] == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_run_checks_circular_dependency():
+    checks = {
+        "circular_a": CircularA,
+        "circular_b": CircularB,
+    }
+    ctx = Context()
+    with pytest.raises(ValueError, match="Circular or unsatisfied"):
+        await run_checks(checks, ctx)
+
+
+@pytest.mark.asyncio
+async def test_run_checks_skips_preexisting_data():
+    """Checks with pre-populated ctx.data are skipped."""
+    ctx = Context(data={"passing": "cached"})
+    await run_checks({"passing": PassingCheck}, ctx)
+    assert ctx.data["passing"] == "cached"
+
+
+@pytest.mark.asyncio
+async def test_run_checks_preexisting_data_satisfies_dependency():
+    """Pre-populated data counts as completed for dependency resolution."""
+    ctx = Context(data={"passing": {"ok": True}})
+    await run_checks({"passing": PassingCheck, "dependent": DependentCheck}, ctx)
+
+    assert ctx.data["passing"] == {"ok": True}
+    assert ctx.data["dependent"] == {"upstream": {"ok": True}}
+
+
+@pytest.mark.asyncio
+async def test_run_checks_empty():
+    """Running with no checks completes immediately."""
+    ctx = Context()
+    await run_checks({}, ctx)
+    assert ctx.data == {}

--- a/uv.lock
+++ b/uv.lock
@@ -91,6 +91,70 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
 name = "rsrr"
 version = "0.1.0"
 source = { editable = "." }
@@ -99,8 +163,20 @@ dependencies = [
     { name = "httpx" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.3.1" },
     { name = "httpx", specifier = ">=0.28.1" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
 ]


### PR DESCRIPTION
closes #11, #10, #9, #6 and most of #3

**Framework**
- base: introduce Context dataclass (carrying ef_project_id, gh_repo, gh/gl tokens, gl_vuln_kw, shared data dict) and a github_get helper; and BaseCheck (base class).
- runner: auto-discover Check classes in src/rsrr/checks/, run them in dependency waves via asyncio.gather, skip transitive dependents on failure, treat pre-populated ctx.data entries as already completed, and emit per-check start/ok/err progress lines on stderr
- cli: Click CLI with `rsrr list` and `rsrr run`; flags for --ef-project-id, --gh-repo, --gh-token/GH_TOKEN, --gl-token/GL_TOKEN, --gl-vuln-kw, --ctx-data for incremental result merging

**Checks**
- ef_project: Get EF project API results
- ef_committers: Fetches detailed profile info for each project committer from the EF API
- ef_inactive_committers: Lists EF committers whose GitHub handle has no commits in the past year
- ef_cves: Returns advisories from the EF vulnerabilities repo matching the project ID
- gh_repos: List all GitHub repos for the project
- gh_repo_clone: Clones the GitHub repo into a temporary directory
- gh_repo_commit_activity: Returns commit count and committers in the past year for each repo
- gh_releases: Fetches all releases and counts releases per year
- gh_alerts: Fetches all Dependabot alerts for a GitHub repo
- gh_security_advisories: Fetches all security advisories for a GitHub repo
- gh_private_vulnerability_reporting: Checks if private vulnerability reporting is enabled for a GitHub repo
- gh_has_dot_github_repo: Checks if each GitHub organization has a .github repo
- gh_default_security_policy: Checks if each GitHub organization has a default SECURITY.md in its .github repo
- gh_scorecard: Runs OpenSSF Scorecard against a GitHub repo
- gh_zizmor: Runs zizmor GitHub Actions security audit on a GitHub repo
- gl_vulnerability_reports: Searches GitLab vulnerability-reports project for issues matching keywords

**Other**
- Add click, httpx runtime deps and pytest/pytest-asyncio dev deps
- Add tests for base.github_get, the CLI surface, and the runner (discovery, dependency waves, failure propagation, pre-populated data)
- Add README (install, usage, access-token URLs with minimum scopes) and CLAUDE.md project guide
- Ignore .venv and result files via .gitignore